### PR TITLE
Add API Mail Gateway security group for mail routing

### DIFF
--- a/src/vodoo/security.py
+++ b/src/vodoo/security.py
@@ -42,6 +42,24 @@ class GroupDefinition:
 
 GROUP_DEFINITIONS: tuple[GroupDefinition, ...] = (
     GroupDefinition(
+        name="API Mail Gateway",
+        comment="Standalone access for mail gateway (message_process via XML-RPC)",
+        access=(
+            # Core mail routing (message_process, message_route)
+            AccessDefinition("mail.message", True, False, False, False),
+            AccessDefinition("mail.message.subtype", True, False, False, False),
+            AccessDefinition("mail.alias", True, True, False, False),
+            AccessDefinition("mail.alias.domain", True, False, False, False),
+            # Author/user resolution (_mail_find_user_for_gateway, _mail_find_partner_from_emails)
+            AccessDefinition("mail.followers", True, False, False, False),
+            AccessDefinition("res.users", True, False, False, False),
+            AccessDefinition("res.partner", True, False, False, False),
+            # Model/data lookups (routing, _xmlid_to_res_id for subtypes)
+            AccessDefinition("ir.model", True, False, False, False),
+            AccessDefinition("ir.model.data", True, False, False, False),
+        ),
+    ),
+    GroupDefinition(
         name="API Base",
         comment="Core API access - required for all service accounts",
         access=(


### PR DESCRIPTION
Adds a new `GroupDefinition` for standalone mail gateway access via XML-RPC (`message_process`).

### Permissions included:
- **Core mail routing**: `mail.message`, `mail.message.subtype`, `mail.alias`, `mail.alias.domain`
- **Author/user resolution**: `mail.followers`, `res.users`, `res.partner`
- **Model/data lookups**: `ir.model`, `ir.model.data`

This enables service accounts to route incoming emails through Odoo's mail gateway with minimal required permissions.