### PR TITLE
fix: move typer and rich to core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "markdown>=3.5.0",
     "httpx>=0.27.0",
+    "typer[all]>=0.12.0",
+    "rich>=13.7.0",
 ]
 
 [project.urls]
@@ -42,10 +44,6 @@ Issues = "https://github.com/julian-r/vodoo/issues"
 vodoo = "vodoo.main:app"
 
 [project.optional-dependencies]
-cli = [
-    "typer[all]>=0.12.0",
-    "rich>=13.7.0",
-]
 dev = [
     "mypy>=1.11.0",
     "ruff>=0.6.0",

--- a/uv.lock
+++ b/uv.lock
@@ -978,13 +978,11 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
-]
-
-[package.optional-dependencies]
-cli = [
     { name = "rich" },
     { name = "typer" },
 ]
+
+[package.optional-dependencies]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
@@ -1013,12 +1011,12 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.5.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "rich", marker = "extra == 'cli'", specifier = ">=13.7.0" },
+    { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
-    { name = "typer", extras = ["all"], marker = "extra == 'cli'", specifier = ">=0.12.0" },
+    { name = "typer", extras = ["all"], specifier = ">=0.12.0" },
     { name = "types-markdown", marker = "extra == 'dev'", specifier = ">=3.5.0" },
 ]
-provides-extras = ["cli", "dev", "docs"]
+provides-extras = ["dev", "docs"]
 
 [[package]]
 name = "watchdog"


### PR DESCRIPTION
Fixes `uvx vodoo` failing with `ModuleNotFoundError: No module named 'typer'`. Also fixes docs deployment which needs typer for CLI reference generation.