### PR TITLE
feat(knowledge): add article create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ vodoo helpdesk download 456 --output ./attachments/
 
 ```bash
 vodoo knowledge list --category workspace
+vodoo knowledge create "Team Handbook" --body "# Onboarding\n\nWelcome!" --category workspace
 vodoo knowledge show 123
 vodoo knowledge note 123 "Updated installation section"
 ```

--- a/docs/cli/knowledge.md
+++ b/docs/cli/knowledge.md
@@ -19,6 +19,25 @@ List knowledge articles.
 | `--category` | TEXT | Filter by category (workspace, private, shared) |
 | `--limit` | INT | Maximum number of articles (default: 50) |
 
+### create
+
+Create a new knowledge article.
+
+**Arguments:**
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `name` | TEXT | Article title |
+
+**Options:**
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--body` / `-b` | TEXT | Article body in markdown |
+| `--parent` / `-p` | INT | Parent article ID |
+| `--category` / `-c` | TEXT | Article category (workspace, private, shared) |
+| `--icon` | TEXT | Emoji/icon for the article (e.g. 📘) |
+
 ### show
 
 Show detailed article information.

--- a/src/vodoo/aio/knowledge.py
+++ b/src/vodoo/aio/knowledge.py
@@ -1,11 +1,34 @@
 """Async knowledge article operations for Vodoo."""
 
+from typing import Any
+
 from vodoo.aio._domain import AsyncDomainNamespace
-from vodoo.knowledge import _KnowledgeAttrs
+from vodoo.knowledge import _build_article_values, _KnowledgeAttrs
 
 
 class AsyncKnowledgeNamespace(_KnowledgeAttrs, AsyncDomainNamespace):
     """Async namespace for knowledge.article model."""
+
+    async def create(
+        self,
+        name: str,
+        *,
+        body: str | None = None,
+        parent_id: int | None = None,
+        category: str | None = None,
+        icon: str | None = None,
+        **extra_fields: Any,
+    ) -> int:
+        """Create a knowledge article."""
+        values = _build_article_values(
+            name,
+            body=body,
+            parent_id=parent_id,
+            category=category,
+            icon=icon,
+            **extra_fields,
+        )
+        return await self._client.create(self._model, values)
 
     async def url(self, record_id: int) -> str:  # type: ignore[override]
         """Get the web URL for a knowledge article.

--- a/src/vodoo/knowledge.py
+++ b/src/vodoo/knowledge.py
@@ -8,6 +8,7 @@ from vodoo.base import (
     _html_to_markdown,
     _is_simple_output,
 )
+from vodoo.content import Markdown
 
 
 class _KnowledgeAttrs:
@@ -32,8 +33,63 @@ class _KnowledgeAttrs:
     _record_type = "Article"
 
 
+def _build_article_values(
+    name: str,
+    *,
+    body: str | None = None,
+    parent_id: int | None = None,
+    category: str | None = None,
+    icon: str | None = None,
+    **extra_fields: Any,
+) -> dict[str, Any]:
+    """Build the values dict for knowledge.article creation."""
+    values: dict[str, Any] = {"name": name, **extra_fields}
+    if body is not None:
+        values["body"] = Markdown(body)
+    if parent_id is not None:
+        values["parent_id"] = parent_id
+    if category is not None:
+        values["category"] = category
+    if icon is not None:
+        values["icon"] = icon
+    return values
+
+
 class KnowledgeNamespace(_KnowledgeAttrs, DomainNamespace):
     """Namespace for knowledge.article model."""
+
+    def create(
+        self,
+        name: str,
+        *,
+        body: str | None = None,
+        parent_id: int | None = None,
+        category: str | None = None,
+        icon: str | None = None,
+        **extra_fields: Any,
+    ) -> int:
+        """Create a knowledge article.
+
+        Args:
+            name: Article title/name.
+            body: Article body as markdown text (converted to HTML).
+            parent_id: Parent article ID.
+            category: Article category (workspace/private/shared).
+            icon: Emoji/icon for the article.
+            **extra_fields: Additional fields to set on the article.
+
+        Returns:
+            ID of created article.
+        """
+        values = _build_article_values(
+            name,
+            body=body,
+            parent_id=parent_id,
+            category=category,
+            icon=icon,
+            **extra_fields,
+        )
+        return self._client.create(self._model, values)
 
     def url(self, record_id: int) -> str:
         """Get the web URL for a knowledge article.

--- a/src/vodoo/main.py
+++ b/src/vodoo/main.py
@@ -1439,6 +1439,43 @@ def knowledge_list(
         console.print(f"\n[dim]Found {len(articles)} articles[/dim]")
 
 
+@knowledge_app.command("create")
+def knowledge_create(
+    name: Annotated[str, typer.Argument(help="Article title")],
+    body: Annotated[
+        str | None,
+        typer.Option("--body", "-b", help="Article body in markdown"),
+    ] = None,
+    parent_id: Annotated[
+        int | None,
+        typer.Option("--parent", "-p", help="Parent article ID"),
+    ] = None,
+    category: Annotated[
+        str | None,
+        typer.Option("--category", "-c", help="Article category (workspace, private, shared)"),
+    ] = None,
+    icon: Annotated[
+        str | None,
+        typer.Option("--icon", help="Emoji/icon for the article (e.g. 📘)"),
+    ] = None,
+) -> None:
+    """Create a new knowledge article."""
+    client = get_client()
+
+    with _handle_errors():
+        article_id = client.knowledge.create(
+            name,
+            body=body,
+            parent_id=parent_id,
+            category=category,
+            icon=icon,
+        )
+        console.print(f"[green]Successfully created article '{name}' with ID {article_id}[/green]")
+
+        url = client.knowledge.url(article_id)
+        console.print(f"\n[cyan]View article:[/cyan] {url}")
+
+
 @knowledge_app.command("show")
 def knowledge_show(
     article_id: Annotated[int, typer.Argument(help="Article ID")],

--- a/tests/integration/test_async_suite.py
+++ b/tests/integration/test_async_suite.py
@@ -927,6 +927,21 @@ class TestAsyncKnowledge:
         article = await async_client.knowledge.get(self.article_id)
         assert article["name"] == "Vodoo Async Test Article"
 
+    async def test_create_article(self, async_client: AsyncOdooClient) -> None:
+        article_id = await async_client.knowledge.create(
+            "Vodoo Async Created Article",
+            body="## Async created by Vodoo",
+            category="workspace",
+        )
+        try:
+            assert article_id > 0
+            article = await async_client.knowledge.get(article_id)
+            assert article["name"] == "Vodoo Async Created Article"
+            assert "Async created by Vodoo" in str(article.get("body", ""))
+        finally:
+            with contextlib.suppress(Exception):
+                await async_client.generic.delete("knowledge.article", article_id)
+
     async def test_article_url(self, async_client: AsyncOdooClient) -> None:
         url = await async_client.knowledge.url(self.article_id)
         assert str(self.article_id) in url

--- a/tests/integration/test_suite.py
+++ b/tests/integration/test_suite.py
@@ -878,6 +878,21 @@ class TestKnowledge:
         article = client.knowledge.get(self.article_id)
         assert article["name"] == "Vodoo Test Article"
 
+    def test_create_article(self, client: OdooClient) -> None:
+        article_id = client.knowledge.create(
+            "Vodoo Created Article",
+            body="## Created by Vodoo",
+            category="workspace",
+        )
+        try:
+            assert article_id > 0
+            article = client.knowledge.get(article_id)
+            assert article["name"] == "Vodoo Created Article"
+            assert "Created by Vodoo" in str(article.get("body", ""))
+        finally:
+            with contextlib.suppress(Exception):
+                client.generic.delete("knowledge.article", article_id)
+
     def test_article_url(self, client: OdooClient) -> None:
         url = client.knowledge.url(self.article_id)
         assert str(self.article_id) in url

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1,0 +1,100 @@
+"""Tests for knowledge article helpers and namespaces."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from vodoo.aio.knowledge import AsyncKnowledgeNamespace
+from vodoo.content import Markdown
+from vodoo.knowledge import KnowledgeNamespace, _build_article_values
+
+
+class _StubClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any], dict[str, Any] | None]] = []
+
+    def create(
+        self,
+        model: str,
+        values: dict[str, Any],
+        context: dict[str, Any] | None = None,
+    ) -> int:
+        self.calls.append((model, values, context))
+        return 101
+
+
+class _StubAsyncClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any], dict[str, Any] | None]] = []
+
+    async def create(
+        self,
+        model: str,
+        values: dict[str, Any],
+        context: dict[str, Any] | None = None,
+    ) -> int:
+        self.calls.append((model, values, context))
+        return 202
+
+
+class TestBuildArticleValues:
+    def test_build_values_with_optional_fields(self) -> None:
+        values = _build_article_values(
+            "Runbook",
+            body="# Hello",
+            parent_id=33,
+            category="workspace",
+            icon="📘",
+            x_custom_field="abc",
+        )
+
+        assert values["name"] == "Runbook"
+        assert isinstance(values["body"], Markdown)
+        assert str(values["body"]) == "# Hello"
+        assert values["parent_id"] == 33
+        assert values["category"] == "workspace"
+        assert values["icon"] == "📘"
+        assert values["x_custom_field"] == "abc"
+
+
+class TestKnowledgeNamespaceCreate:
+    def test_sync_create_calls_client_create(self) -> None:
+        client = _StubClient()
+        namespace = KnowledgeNamespace(client=client)  # type: ignore[arg-type]
+
+        article_id = namespace.create(
+            "Team Handbook",
+            body="## Intro",
+            category="workspace",
+        )
+
+        assert article_id == 101
+        assert len(client.calls) == 1
+        model, values, context = client.calls[0]
+        assert model == "knowledge.article"
+        assert context is None
+        assert values["name"] == "Team Handbook"
+        assert isinstance(values["body"], Markdown)
+        assert values["category"] == "workspace"
+
+    def test_async_create_calls_client_create(self) -> None:
+        client = _StubAsyncClient()
+        namespace = AsyncKnowledgeNamespace(client=client)  # type: ignore[arg-type]
+
+        article_id = asyncio.run(
+            namespace.create(
+                "Async Handbook",
+                body="Async body",
+                parent_id=12,
+            )
+        )
+
+        assert article_id == 202
+        assert len(client.calls) == 1
+        model, values, context = client.calls[0]
+        assert model == "knowledge.article"
+        assert context is None
+        assert values["name"] == "Async Handbook"
+        assert isinstance(values["body"], Markdown)
+        assert values["parent_id"] == 12


### PR DESCRIPTION
## Summary

Adds first-class knowledge article creation support in both the Python API and CLI.

Closes #36.

## What changed

- Added `KnowledgeNamespace.create(...)` in `src/vodoo/knowledge.py`
- Added `AsyncKnowledgeNamespace.create(...)` in `src/vodoo/aio/knowledge.py`
- Added value builder helper for articles: `_build_article_values(...)`
  - supports `name`, `body`, `parent_id`, `category`, `icon`, and extra fields
  - converts `body` markdown to HTML via existing `Markdown` content wrapper path

### New CLI command

- `vodoo knowledge create <name> [--body/-b ...] [--parent/-p ...] [--category/-c ...] [--icon ...]`

The command prints created article ID and its URL.

### Tests

- Added unit tests: `tests/test_knowledge.py`
  - article value builder behavior
  - sync/async `create()` delegation behavior
- Added integration tests:
  - `TestKnowledge.test_create_article`
  - `TestAsyncKnowledge.test_create_article`

### Docs

- Updated generated CLI docs: `docs/cli/knowledge.md`
- Updated README examples for knowledge usage

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/vodoo`
- `uv run pytest tests -q`
- `ENTERPRISE=1 KEEP=1 ./tests/integration/run.sh 19`
  - Community: `105 passed, 54 skipped`
  - Enterprise: `157 passed, 2 skipped`
